### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following packages are required to build KaM League:
 * Elixir >= 1.9
 * npm >= 6.13.4
 * PostgreSQL
+* inotify-tools
 
 Run the following commands:
 


### PR DESCRIPTION
Don't know whether this is really essential but without inotify-tools package installed, you'd get this error upon running setup:
$ mix ecto.setup
....
[error] `inotify-tools` is needed to run `file_system` for your system, check https://github.com/rvoicilas/inotify-tools/wiki for more information about how to install it. If it's already installed but not be found, appoint executable file with `config.exs` or `FILESYSTEM_FSINOTIFY_EXECUTABLE_FILE` env.
[warn] Could not start Phoenix live-reload because we cannot listen to the file system.
You don't need to worry! This is an optional feature used during development to
refresh your browser when you save files and it does not affect production.

warning: :simple_one_for_one strategy is deprecated, please use DynamicSupervisor instead
  (elixir 1.12.2) lib/supervisor.ex:604: Supervisor.init/2
  (elixir 1.12.2) lib/supervisor.ex:556: Supervisor.start_link/2
  (libring 1.4.0) lib/app.ex:13: HashRing.App.start/2
  (kernel 8.1.2) application_master.erl:293: :application_master.start_it_old/4